### PR TITLE
add a hacky patch to fix many test errors

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/pandas-dev/pandas/releases/download/v{{ version }}/pandas-{{ version }}.tar.gz
   sha256: c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c
+  patches:
+    - patches/0001-fix-find_stack_level-for-functools.patch
 
 build:
   number: 1

--- a/recipe/patches/0001-fix-find_stack_level-for-functools.patch
+++ b/recipe/patches/0001-fix-find_stack_level-for-functools.patch
@@ -1,0 +1,23 @@
+From 437bdeee1715c399f1ab820b247b4fa6391734f7 Mon Sep 17 00:00:00 2001
+From: mattip <matti.picus@gmail.com>
+Date: Thu, 10 Aug 2023 01:56:28 +0300
+Subject: [PATCH] fix find_stack_level for functools
+
+---
+ pandas/util/_exceptions.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/pandas/util/_exceptions.py b/pandas/util/_exceptions.py
+index f300f2c52f..2235d35392 100644
+--- a/pandas/util/_exceptions.py
++++ b/pandas/util/_exceptions.py
+@@ -43,7 +43,8 @@ def find_stack_level() -> int:
+     n = 0
+     while frame:
+         fname = inspect.getfile(frame)
+-        if fname.startswith(pkg_dir) and not fname.startswith(test_dir):
++        if fname.endswith("functools.py") or (
++                fname.startswith(pkg_dir) and not fname.startswith(test_dir)):
+             frame = frame.f_back
+             n += 1
+         else:


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/54478

I am pretty sure this is not the correct fix, but it should reduce the number of failed tests by half with a one-liner.